### PR TITLE
Fix run example

### DIFF
--- a/vanilla-js/scripts/run-example.js
+++ b/vanilla-js/scripts/run-example.js
@@ -27,7 +27,6 @@ process.env.DESCRIPTION = example.description;
 process.env.FILENAME = example.filename;
 
 // Run the example
-// removed internal npm call to run-example and instead added the commands directly here aas env variables are not getting passed"
 try {
   execSync("echo \"=== $TITLE ===\" && node ./scripts/typewriter.js \"$DESCRIPTION\" && bat --language=js --theme=\"OneHalfDark\" $FILENAME && node $FILENAME", { stdio: "inherit", timeout: 20000 }); // 20-second timeout
 } catch (error) {

--- a/vanilla-js/scripts/run-example.js
+++ b/vanilla-js/scripts/run-example.js
@@ -28,7 +28,7 @@ process.env.FILENAME = example.filename;
 
 // Run the example
 try {
-  execSync("npm run --silent run-example", { stdio: "inherit", timeout: 20000 }); // 20-second timeout
+  execSync("echo \"=== $TITLE ===\" && node ./scripts/typewriter.js \"$DESCRIPTION\" && bat --language=js --theme=\"OneHalfDark\" $FILENAME && node $FILENAME", { stdio: "inherit", timeout: 20000 }); // 20-second timeout
 } catch (error) {
   console.error("Error running example script:", error);
   process.exit(1);

--- a/vanilla-js/scripts/run-example.js
+++ b/vanilla-js/scripts/run-example.js
@@ -27,6 +27,7 @@ process.env.DESCRIPTION = example.description;
 process.env.FILENAME = example.filename;
 
 // Run the example
+// removed internal npm call to run-example and instead added the commands directly here aas env variables are not getting passed"
 try {
   execSync("echo \"=== $TITLE ===\" && node ./scripts/typewriter.js \"$DESCRIPTION\" && bat --language=js --theme=\"OneHalfDark\" $FILENAME && node $FILENAME", { stdio: "inherit", timeout: 20000 }); // 20-second timeout
 } catch (error) {


### PR DESCRIPTION
removed internal npm call to run-example from the execSync fucntion and instead added the commands directly here as env variables are not getting passed